### PR TITLE
feat: cpu-function altered to support cpus-per-gpu, too

### DIFF
--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -154,7 +154,11 @@ class Executor(RealExecutor):
 
 
 def get_cpu_setting(job: JobExecutorInterface, gpu: bool) -> str:
+    # per default, we assume that Snakemake's threads are the same as the 
+    # cpus per task or per gpu. If the user has set the cpus_per_task or 
+    # cpus_per_gpu explicitly, we use these values.
     cpus_per_task = cpus_per_gpu = job.threads
+    # cpus_per_task and cpus_per_gpu are mutually exclusive
     if job.resources.get("cpus_per_task"):
         cpus_per_task = job.resources.cpus_per_task
         if not isinstance(cpus_per_task, int):
@@ -177,11 +181,9 @@ def get_cpu_setting(job: JobExecutorInterface, gpu: bool) -> str:
             )
         # If explicetily set to < 0, return an empty string
         # some clusters do not allow CPU settings (e.g. in GPU partitions).
+        # Currently, 0 is not allowed by SLURM.
         if cpus_per_gpu <= 0:
             return ""
-        # ensure that at least 1 cpu is requested
-        # because 0 is not allowed by slurm
-        cpus_per_gpu = max(1, job.resources.cpus_per_gpu)
         return f"--cpus-per-gpu={cpus_per_gpu}"
     else:
         return f"--cpus-per-task={cpus_per_task}"

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -177,7 +177,7 @@ def get_cpu_setting(job: JobExecutorInterface, gpu: bool) -> str:
             )
         # If explicetily set to < 0, return an empty string
         # some clusters do not allow CPU settings (e.g. in GPU partitions).
-        if cpus_per_gpu < 0:
+        if cpus_per_gpu <= 0:
             return ""
         # ensure that at least 1 cpu is requested
         # because 0 is not allowed by slurm


### PR DESCRIPTION
This PR works in combination with https://github.com/snakemake/snakemake-executor-plugin-slurm/pull/173, only. It sees changes in the function to get the cpu settings.

- it is possible to ommit cpu-settins upon submission, now. Required, because apparently some clusters do not allow this for GPU jobs (which is crazy, but the way we do it know, should not break workflows)
- it is possible now to require CPUs using `--cpus-per-gpu`, too. (Only for GPU jobs, of course.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced SLURM executor plugin with improved GPU job support.
  - Added more flexible CPU and GPU resource allocation handling.

- **Bug Fixes**
  - Improved resource specification logic for different cluster configurations.
  - Better handling of CPU allocation for GPU and non-GPU jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->