### PR TITLE
feat: added handing and unpacking of job information for array jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ black = ">=23.7,<26.0"
 flake8 = ">=6.1,<8.0"
 coverage = "^7.3.1"
 pytest = ">=7.4.2,<10.0.0"
-snakemake = "^9.1.1"
+snakemake = ">9.1.1"
 
 [tool.coverage.run]
 omit = [".*", "*/site-packages/*", "Snakefile"]

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -77,7 +77,6 @@ class ExecutorSettings(ExecutorSettingsBase):
     )
 
 
-
 # Required:
 # Implementation of your executor
 class Executor(RealExecutor):
@@ -88,7 +87,7 @@ class Executor(RealExecutor):
         # we consider this job to be a GPU job, if a GPU has been reserved
         self.gpu_job = os.getenv("SLURM_GPUS")
         # check if SLURM_ARRAY_TASK_ID is set, to determine whether this is a job array task
-        self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None   
+        self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None
 
     def run_job(self, job: JobExecutorInterface):
         # Implement here how to run a job.
@@ -157,21 +156,29 @@ class Executor(RealExecutor):
             min_array_index = min(int(key) for key in array_execs.keys())
             if array_index == min_array_index:
                 # in this case we need to pass the exec strings of
-                # as for a single job, but with the extracted 
+                # as for a single job, but with the extracted
                 # --slurm-jobstep-array-execs flag
                 call = self.format_job_exec(job)
-                index = call.find("--slurm-jobstep-array-execs")
-                if index != -1:
-                    call = call[:index]
-                self.logger.debug(f"Handling first job array task with index {array_index}")
+                # index = call.find("--slurm-jobstep-array-execs")
+                # if index != -1:
+                #    call = call[:index]
+                # Remove the --slurm-jobstep-array-execs flag and its value
+                call = re.sub(r"--slurm-jobstep-array-execs\s+\S+\s*", "", call)
+                self.logger.debug(
+                    f"Handling first job array task with index {array_index}"
+                )
                 self.logger.debug(f"Raw call for first array index: {call}")
             else:
                 self.logger.debug(f"Handling job array task with index {array_index}")
-                self.logger.debug(f"Raw array execs: {self.workflow.executor_settings.array_execs}") 
+                self.logger.debug(
+                    f"Raw array execs: {self.workflow.executor_settings.array_execs}"
+                )
                 compressed_hex = array_execs[str(array_index)]
                 compressed_bytes = bytes.fromhex(compressed_hex)
                 call = zlib.decompress(compressed_bytes).decode("utf-8")
-                self.logger.debug(f"Decompressed call for array index {array_index}: {call}")
+                self.logger.debug(
+                    f"Decompressed call for array index {array_index}: {call}"
+                )
         else:
             # SMP job, execute snakemake with srun, to ensure proper placing of threaded
             # executables within the c-group

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -164,7 +164,6 @@ class Executor(RealExecutor):
             else:
                 self.logger.debug(f"Handling job array task with index {array_index}")
                 self.logger.debug(f"Raw array execs: {self.workflow.executor_settings.array_execs}") 
-                self.logger.debug(f"type of raw array execs: {type(self.workflow.executor_settings.array_execs)} ")
                 # extract the exec string from the passed json dict:
                 array_execs = parse_array_execs(self.workflow.executor_settings.array_execs)
                 compressed_hex = array_execs[str(array_index)]

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -151,10 +151,14 @@ class Executor(RealExecutor):
         # this is an array job
         elif self.job_array_task and self.workflow.executor_settings.array_execs:
             array_index = int(os.getenv("SLURM_ARRAY_TASK_ID"))
-            if array_index == 1:
+            # extract the exec string from the passed json dict:
+            array_execs = parse_array_execs(self.workflow.executor_settings.array_execs)
+            # get the minimum array index to determine the first task of the job array
+            min_array_index = min(int(key) for key in array_execs.keys())
+            if array_index == min_array_index:
                 # in this case we need to pass the exec strings of
                 # as for a single job, but with the extracted 
-                # --slurm-jobstep-arrays-execs flag
+                # --slurm-jobstep-array-execs flag
                 call = self.format_job_exec(job)
                 index = call.find("--slurm-jobstep-array-execs")
                 if index != -1:
@@ -164,8 +168,6 @@ class Executor(RealExecutor):
             else:
                 self.logger.debug(f"Handling job array task with index {array_index}")
                 self.logger.debug(f"Raw array execs: {self.workflow.executor_settings.array_execs}") 
-                # extract the exec string from the passed json dict:
-                array_execs = parse_array_execs(self.workflow.executor_settings.array_execs)
                 compressed_hex = array_execs[str(array_index)]
                 compressed_bytes = bytes.fromhex(compressed_hex)
                 call = zlib.decompress(compressed_bytes).decode("utf-8")
@@ -281,7 +283,7 @@ def get_cpu_setting(job: JobExecutorInterface, gpu: bool) -> str:
         return f"--cpus-per-task={cpus_per_task}"
 
 
-def parse_array_execs(raw_array_execs):
+def parse_array_execs(raw_array_execs) -> dict:
     """Parse array exec mapping from executor settings.
 
     Accepts strict JSON and Python literal dict strings for compatibility with
@@ -334,7 +336,7 @@ def parse_array_execs(raw_array_execs):
     return normalized
 
 
-def _parse_compact_array_execs(raw_array_execs: str):
+def _parse_compact_array_execs(raw_array_execs: str) -> dict | None:
     """Parse compact dict-like mapping with bare hex values.
 
     Expected shape: {2: a0ff..., 3: b19e...}
@@ -348,7 +350,7 @@ def _parse_compact_array_execs(raw_array_execs: str):
         return {}
 
     pair_pattern = re.compile(r"\s*([0-9]+)\s*:\s*([0-9a-fA-F]+)\s*(?:,|$)")
-    parsed = {}
+    parsed: dict[str, str] = {}
     position = 0
     while position < len(inner):
         while position < len(inner) and inner[position].isspace():

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -65,7 +65,7 @@ class ExecutorSettings(ExecutorSettingsBase):
         },
     )
     array_execs: str = field(
-        default=False,
+        default="",
         metadata={
             "help": (
                 "When a job array is used, this flag, will receive all job excec "

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -77,7 +77,6 @@ class ExecutorSettings(ExecutorSettingsBase):
     )
 
 
-
 # Required:
 # Implementation of your executor
 class Executor(RealExecutor):
@@ -88,7 +87,7 @@ class Executor(RealExecutor):
         # we consider this job to be a GPU job, if a GPU has been reserved
         self.gpu_job = os.getenv("SLURM_GPUS")
         # check if SLURM_ARRAY_TASK_ID is set, to determine whether this is a job array task
-        self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None   
+        self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None
 
     def run_job(self, job: JobExecutorInterface):
         # Implement here how to run a job.
@@ -153,24 +152,34 @@ class Executor(RealExecutor):
             array_index = int(os.getenv("SLURM_ARRAY_TASK_ID"))
             if array_index == 1:
                 # in this case we need to pass the exec strings of
-                # as for a single job, but with the extracted 
+                # as for a single job, but with the extracted
                 # --slurm-jobstep-arrays-execs flag
                 call = self.format_job_exec(job)
                 index = call.find("--slurm-jobstep-array-execs")
                 if index != -1:
                     call = call[:index]
-                self.logger.debug(f"Handling first job array task with index {array_index}")
+                self.logger.debug(
+                    f"Handling first job array task with index {array_index}"
+                )
                 self.logger.debug(f"Raw call for first array index: {call}")
             else:
                 self.logger.debug(f"Handling job array task with index {array_index}")
-                self.logger.debug(f"Raw array execs: {self.workflow.executor_settings.array_execs}") 
-                self.logger.debug(f"type of raw array execs: {type(self.workflow.executor_settings.array_execs)} ")
+                self.logger.debug(
+                    f"Raw array execs: {self.workflow.executor_settings.array_execs}"
+                )
+                self.logger.debug(
+                    f"type of raw array execs: {type(self.workflow.executor_settings.array_execs)} "
+                )
                 # extract the exec string from the passed json dict:
-                array_execs = parse_array_execs(self.workflow.executor_settings.array_execs)
+                array_execs = parse_array_execs(
+                    self.workflow.executor_settings.array_execs
+                )
                 compressed_hex = array_execs[str(array_index)]
                 compressed_bytes = bytes.fromhex(compressed_hex)
                 call = zlib.decompress(compressed_bytes).decode("utf-8")
-                self.logger.debug(f"Decompressed call for array index {array_index}: {call}")
+                self.logger.debug(
+                    f"Decompressed call for array index {array_index}: {call}"
+                )
         else:
             # SMP job, execute snakemake with srun, to ensure proper placing of threaded
             # executables within the c-group

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -86,7 +86,8 @@ class Executor(RealExecutor):
         self.jobid = os.getenv("SLURM_JOB_ID")
         # we consider this job to be a GPU job, if a GPU has been reserved
         self.gpu_job = os.getenv("SLURM_GPUS")
-        # check if SLURM_ARRAY_TASK_ID is set, to determine whether this is a job array task
+        # check if SLURM_ARRAY_TASK_ID is set, to determine whether this
+        # is a job array task
         self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None
 
     def run_job(self, job: JobExecutorInterface):
@@ -174,7 +175,8 @@ class Executor(RealExecutor):
                     f"Raw array execs: {self.workflow.executor_settings.array_execs}"
                 )
                 self.logger.debug(
-                    f"type of raw array execs: {type(self.workflow.executor_settings.array_execs)} "
+                    "type of raw array execs: "
+                    f"{type(self.workflow.executor_settings.array_execs)} "
                 )
                 # extract the exec string from the passed json dict:
                 array_execs = parse_array_execs(

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -7,6 +7,10 @@ import os
 import socket
 import subprocess
 import sys
+import json
+import ast
+import re
+import zlib
 from dataclasses import dataclass, field
 from snakemake_interface_executor_plugins.executors.base import SubmittedJobInfo
 from snakemake_interface_executor_plugins.executors.real import RealExecutor
@@ -54,12 +58,24 @@ class ExecutorSettings(ExecutorSettingsBase):
                 "Pass to srun the command to be executed as a shell script "
                 "(fed through stdin) instead of wrapping it in the command line "
                 "call. Useful when a limit exists on SLURM command line length (ie. "
-                "max_submit_line_size)."
+                "max_submit_line_size). (internal use only)"
             ),
             "env_var": False,
             "required": False,
         },
     )
+    array_execs: str = field(
+        default=False,
+        metadata={
+            "help": (
+                "When a job array is used, this flag, will receive all job excec "
+                "strings as a json dict. (internal use only)"
+            ),
+            "env_var": False,
+            "required": False,
+        },
+    )
+
 
 
 # Required:
@@ -71,6 +87,8 @@ class Executor(RealExecutor):
         self.jobid = os.getenv("SLURM_JOB_ID")
         # we consider this job to be a GPU job, if a GPU has been reserved
         self.gpu_job = os.getenv("SLURM_GPUS")
+        # check if SLURM_ARRAY_TASK_ID is set, to determine whether this is a job array task
+        self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None   
 
     def run_job(self, job: JobExecutorInterface):
         # Implement here how to run a job.
@@ -82,6 +100,7 @@ class Executor(RealExecutor):
         # snakemake_interface_executor_plugins.executors.base.SubmittedJobInfo.
 
         jobsteps = dict()
+        call = None
         srun_script = None
         # TODO revisit special handling for group job levels via srun at a later stage
         # if job.is_group():
@@ -129,6 +148,29 @@ class Executor(RealExecutor):
             # AND there can be stuff around the srun call within the job, like any
             # commands which should be executed before.
             call = self.format_job_exec(job)
+        # this is an array job
+        elif self.job_array_task and self.workflow.executor_settings.array_execs:
+            array_index = int(os.getenv("SLURM_ARRAY_TASK_ID"))
+            if array_index == 1:
+                # in this case we need to pass the exec strings of
+                # as for a single job, but with the extracted 
+                # --slurm-jobstep-arrays-execs flag
+                call = self.format_job_exec(job)
+                index = call.find("--slurm-jobstep-array-execs")
+                if index != -1:
+                    call = call[:index]
+                self.logger.debug(f"Handling first job array task with index {array_index}")
+                self.logger.debug(f"Raw call for first array index: {call}")
+            else:
+                self.logger.debug(f"Handling job array task with index {array_index}")
+                self.logger.debug(f"Raw array execs: {self.workflow.executor_settings.array_execs}") 
+                self.logger.debug(f"type of raw array execs: {type(self.workflow.executor_settings.array_execs)} ")
+                # extract the exec string from the passed json dict:
+                array_execs = parse_array_execs(self.workflow.executor_settings.array_execs)
+                compressed_hex = array_execs[str(array_index)]
+                compressed_bytes = bytes.fromhex(compressed_hex)
+                call = zlib.decompress(compressed_bytes).decode("utf-8")
+                self.logger.debug(f"Decompressed call for array index {array_index}: {call}")
         else:
             # SMP job, execute snakemake with srun, to ensure proper placing of threaded
             # executables within the c-group
@@ -238,3 +280,88 @@ def get_cpu_setting(job: JobExecutorInterface, gpu: bool) -> str:
         return f"--cpus-per-gpu={cpus_per_gpu}"
     else:
         return f"--cpus-per-task={cpus_per_task}"
+
+
+def parse_array_execs(raw_array_execs):
+    """Parse array exec mapping from executor settings.
+
+    Accepts strict JSON and Python literal dict strings for compatibility with
+    shell/CLI forwarding that may rewrite quotes.
+    """
+    if isinstance(raw_array_execs, dict):
+        parsed = raw_array_execs
+
+    elif not isinstance(raw_array_execs, str):
+        raise WorkflowError(
+            "Invalid value for executor setting `array_execs`: expected str or dict."
+        )
+    else:
+        try:
+            parsed = json.loads(raw_array_execs)
+        except json.JSONDecodeError:
+            try:
+                parsed = ast.literal_eval(raw_array_execs)
+            except (SyntaxError, ValueError):
+                parsed = _parse_compact_array_execs(raw_array_execs)
+                if parsed is None:
+                    raise WorkflowError(
+                        "Failed to parse executor setting `array_execs`. "
+                        "Expected JSON, Python dict literal, or compact mapping."
+                    ) from None
+
+    if not isinstance(parsed, dict):
+        raise WorkflowError(
+            "Invalid value for executor setting `array_execs`: expected mapping."
+        )
+
+    normalized = {}
+    for key, value in parsed.items():
+        key_str = str(key).strip()
+        if not key_str:
+            raise WorkflowError(
+                "Invalid value for executor setting `array_execs`: empty task id key."
+            )
+
+        if not isinstance(value, str):
+            value = str(value)
+        value = value.strip()
+        if not value or not re.fullmatch(r"[0-9a-fA-F]+", value):
+            raise WorkflowError(
+                "Invalid value for executor setting `array_execs`: values must be "
+                "hex-encoded strings."
+            )
+        normalized[key_str] = value
+
+    return normalized
+
+
+def _parse_compact_array_execs(raw_array_execs: str):
+    """Parse compact dict-like mapping with bare hex values.
+
+    Expected shape: {2: a0ff..., 3: b19e...}
+    """
+    text = raw_array_execs.strip()
+    if not (text.startswith("{") and text.endswith("}")):
+        return None
+
+    inner = text[1:-1]
+    if not inner.strip():
+        return {}
+
+    pair_pattern = re.compile(r"\s*([0-9]+)\s*:\s*([0-9a-fA-F]+)\s*(?:,|$)")
+    parsed = {}
+    position = 0
+    while position < len(inner):
+        while position < len(inner) and inner[position].isspace():
+            position += 1
+        if position >= len(inner):
+            break
+
+        match = pair_pattern.match(inner, position)
+        if match is None:
+            return None
+
+        parsed[match.group(1)] = match.group(2)
+        position = match.end()
+
+    return parsed

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -160,11 +160,9 @@ class Executor(RealExecutor):
                 # as for a single job, but with the extracted
                 # --slurm-jobstep-array-execs flag
                 call = self.format_job_exec(job)
-                # index = call.find("--slurm-jobstep-array-execs")
-                # if index != -1:
-                #    call = call[:index]
-                # Remove the --slurm-jobstep-array-execs flag and its value
-                call = re.sub(r"--slurm-jobstep-array-execs\s+\S+\s*", "", call)
+                index = call.find("--slurm-jobstep-array-execs")
+                if index != -1:
+                    call = call[:index]
                 self.logger.debug(
                     f"Handling first job array task with index {array_index}"
                 )

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -3,6 +3,8 @@ __copyright__ = "Copyright 2023, David Lähnemann, Johannes Köster, Christian M
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+import base64
+import binascii
 import os
 import socket
 import subprocess
@@ -153,33 +155,17 @@ class Executor(RealExecutor):
             array_index = int(os.getenv("SLURM_ARRAY_TASK_ID"))
             # extract the exec string from the passed json dict:
             array_execs = parse_array_execs(self.workflow.executor_settings.array_execs)
-            # get the minimum array index to determine the first task of the job array
-            min_array_index = min(int(key) for key in array_execs.keys())
-            if array_index == min_array_index:
-                # in this case we need to pass the exec strings of
-                # as for a single job, but with the extracted
-                # --slurm-jobstep-array-execs flag
-                call = self.format_job_exec(job)
-                index = call.find("--slurm-jobstep-array-execs")
-                if index != -1:
-                    call = call[:index]
+            # The first task is intentionally not included in the compressed
+            # mapping and is represented by the main job_exec string up to
+            # --slurm-jobstep-array-execs.
+            is_first_task = str(array_index) not in array_execs
+            if is_first_task:
+                raw_call = self.format_job_exec(job)
+                call = strip_array_execs_option(raw_call)
                 self.logger.debug(
-                    f"Handling first job array task with index {array_index}"
+                    f"Using raw call for first array task index {array_index}: {call}"
                 )
-                self.logger.debug(f"Raw call for first array index: {call}")
             else:
-                self.logger.debug(f"Handling job array task with index {array_index}")
-                self.logger.debug(
-                    f"Raw array execs: {self.workflow.executor_settings.array_execs}"
-                )
-                self.logger.debug(
-                    "type of raw array execs: "
-                    f"{type(self.workflow.executor_settings.array_execs)} "
-                )
-                # extract the exec string from the passed json dict:
-                array_execs = parse_array_execs(
-                    self.workflow.executor_settings.array_execs
-                )
                 compressed_hex = array_execs[str(array_index)]
                 compressed_bytes = bytes.fromhex(compressed_hex)
                 call = zlib.decompress(compressed_bytes).decode("utf-8")
@@ -311,9 +297,16 @@ def parse_array_execs(raw_array_execs) -> dict:
             "Invalid value for executor setting `array_execs`: expected str or dict."
         )
     else:
+        candidate = raw_array_execs.strip()
+        if (
+            len(candidate) >= 2
+            and candidate[0] == candidate[-1]
+            and candidate[0] in ("'", '"')
+        ):
+            candidate = candidate[1:-1]
         try:
-            parsed = json.loads(raw_array_execs)
-        except json.JSONDecodeError:
+            parsed = json.loads(base64.b64decode(candidate))
+        except (json.JSONDecodeError, binascii.Error, ValueError, TypeError):
             try:
                 parsed = ast.literal_eval(raw_array_execs)
             except (SyntaxError, ValueError):
@@ -348,6 +341,18 @@ def parse_array_execs(raw_array_execs) -> dict:
         normalized[key_str] = value
 
     return normalized
+
+
+def strip_array_execs_option(command: str) -> str:
+    """Strip --slurm-jobstep-array-execs and all trailing arguments.
+
+    Truncates the command at the first occurrence of --slurm-jobstep-array-execs
+    (in either --flag=value or --flag value form).
+    """
+    match = re.search(r"\s*--slurm-jobstep-array-execs(?:=|\s)", command)
+    if match:
+        return command[: match.start()].rstrip()
+    return command
 
 
 def _parse_compact_array_execs(raw_array_execs: str) -> dict | None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,11 +1,16 @@
 from typing import Optional
 import os
+import base64
 import pytest
 import snakemake.common.tests
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 from snakemake_interface_common.exceptions import WorkflowError
 
-from snakemake_executor_plugin_slurm_jobstep import ExecutorSettings, parse_array_execs
+from snakemake_executor_plugin_slurm_jobstep import (
+    ExecutorSettings,
+    parse_array_execs,
+    strip_array_execs_option,
+)
 
 
 # Inserted for local test for utility functions, which do not require SLURM
@@ -43,6 +48,66 @@ def test_parse_array_execs_compact_mapping():
     assert parsed == {"2": "a1b2", "6": "deadbeef"}
 
 
+def test_parse_array_execs_base64_json_unquoted():
+    raw = '{"2": "a1b2", "6": "deadbeef"}'
+    encoded = base64.b64encode(raw.encode("utf-8")).decode("ascii")
+    parsed = parse_array_execs(encoded)
+    assert parsed == {"2": "a1b2", "6": "deadbeef"}
+
+
+def test_parse_array_execs_base64_json_single_quoted():
+    raw = '{"2": "a1b2", "6": "deadbeef"}'
+    encoded = base64.b64encode(raw.encode("utf-8")).decode("ascii")
+    parsed = parse_array_execs(f"'{encoded}'")
+    assert parsed == {"2": "a1b2", "6": "deadbeef"}
+
+
 def test_parse_array_execs_invalid_value_raises():
     with pytest.raises(WorkflowError, match="hex-encoded"):
         parse_array_execs('{"2": "not-hex"}')
+
+
+def test_strip_array_execs_option_equals_form():
+    cmd = (
+        "python -m snakemake --executor slurm-jobstep "
+        "--slurm-jobstep-array-execs='{" + '"2": "a1b2"' + "}' --jobs 1"
+    )
+    stripped = strip_array_execs_option(cmd)
+    assert "--slurm-jobstep-array-execs" not in stripped
+    assert "--executor slurm-jobstep" in stripped
+    assert "--jobs 1" not in stripped
+
+
+def test_strip_array_execs_option_base64_quoted_form():
+    payload = "eyIyIjogImExYjIiLCAiNiI6ICJkZWFkYmVlZiJ9"
+    cmd = (
+        "python -m snakemake --executor slurm-jobstep "
+        f"--slurm-jobstep-array-execs='{payload}' --jobs 1"
+    )
+    stripped = strip_array_execs_option(cmd)
+    assert "--slurm-jobstep-array-execs" not in stripped
+    assert "--executor slurm-jobstep" in stripped
+    assert "--jobs 1" not in stripped
+
+
+def test_strip_array_execs_option_base64_unquoted_form():
+    payload = "eyIyIjogImExYjIiLCAiNiI6ICJkZWFkYmVlZiJ9"
+    cmd = (
+        "python -m snakemake --executor slurm-jobstep "
+        f"--slurm-jobstep-array-execs={payload} --jobs 1"
+    )
+    stripped = strip_array_execs_option(cmd)
+    assert "--slurm-jobstep-array-execs" not in stripped
+    assert "--executor slurm-jobstep" in stripped
+    assert "--jobs 1" not in stripped
+
+
+def test_strip_array_execs_option_separate_form():
+    cmd = (
+        "python -m snakemake --executor slurm-jobstep "
+        "--slurm-jobstep-array-execs '{2: a1b2, 3: deadbeef}' --jobs 1"
+    )
+    stripped = strip_array_execs_option(cmd)
+    assert "--slurm-jobstep-array-execs" not in stripped
+    assert "--executor slurm-jobstep" in stripped
+    assert "--jobs 1" not in stripped

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,8 +8,8 @@ from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_executor_plugin_slurm_jobstep import ExecutorSettings, parse_array_execs
 
 
-# Inserted for local test for utitlity functions, which do not require SLURM
-@pytest.mark.skipif(
+# Inserted for local test for utility functions, which do not require SLURM
+`@pytest.mark.skipif`(
     os.getenv("SLURM_JOB_ID") is None,
     reason="Workflow integration tests require running inside a SLURM allocation.",
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,18 @@
 from typing import Optional
+import os
+import pytest
 import snakemake.common.tests
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
+from snakemake_interface_common.exceptions import WorkflowError
 
-from snakemake_executor_plugin_slurm_jobstep import ExecutorSettings
+from snakemake_executor_plugin_slurm_jobstep import ExecutorSettings, parse_array_execs
 
 
+# Inserted for local test for utitlity functions, which do not require SLURM
+@pytest.mark.skipif(
+    os.getenv("SLURM_JOB_ID") is None,
+    reason="Workflow integration tests require running inside a SLURM allocation.",
+)
 class TestWorkflowsBase(snakemake.common.tests.TestWorkflowsLocalStorageBase):
     __test__ = True
 
@@ -18,3 +26,23 @@ class TestWorkflowsBase(snakemake.common.tests.TestWorkflowsLocalStorageBase):
 
 # def test_issue_41():
 #    run(dpath("test_github_issue41"))
+
+
+def test_parse_array_execs_json():
+    parsed = parse_array_execs('{"2": "a1b2", "6": "deadbeef"}')
+    assert parsed == {"2": "a1b2", "6": "deadbeef"}
+
+
+def test_parse_array_execs_python_literal():
+    parsed = parse_array_execs("{2: 'a1b2', 6: 'deadbeef'}")
+    assert parsed == {"2": "a1b2", "6": "deadbeef"}
+
+
+def test_parse_array_execs_compact_mapping():
+    parsed = parse_array_execs("{2: a1b2, 6: deadbeef}")
+    assert parsed == {"2": "a1b2", "6": "deadbeef"}
+
+
+def test_parse_array_execs_invalid_value_raises():
+    with pytest.raises(WorkflowError, match="hex-encoded"):
+        parse_array_execs('{"2": "not-hex"}')


### PR DESCRIPTION
This is the corresponding PR to    
https://github.com/snakemake/snakemake-executor-plugin-slurm/pull/174 - handling selection and decompression of job information for SLURM array jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced SLURM array-job support: runtime detection of array task index, optional per-task command handling (supports hex-encoded compressed per-task commands), configurable array-exec option, and clearer parsing/error messages.

* **Tests**
  * Added unit tests for array-exec parsing covering JSON, Python-literal, compact-mapping formats, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->