### PR TITLE
feat: stage-in of input files on node local storage

### DIFF
--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -35,6 +35,7 @@ from .stagein import (
     expand_node_local_prefix,
     should_stage_in,
     get_file_size,
+    check_filesystem_availability,
     stage_in_sbcast,
     stage_in_scp,
 )
@@ -149,6 +150,13 @@ class Executor(RealExecutor):
             if should_stage_in(inputfile):
                 # if the file size is < 2GB, we use sbcast, otherwise scp
                 size = get_file_size(inputfile)
+                if size is not None and size > check_filesystem_availability(
+                    self.node_local_prefix
+                ):
+                    raise WorkflowError(
+                        f"Not enough available space on filesystem for staging in {inputfile} "
+                        f"(size: {size} GB, available: {check_filesystem_availability(self.node_local_prefix)} GB)."
+                    )
                 if size is not None and size < 2:
                     self.logger.debug(
                         f"Staging in {inputfile} via sbcast (size: {size} GB)"

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -157,7 +157,7 @@ class Executor(RealExecutor):
                         f"Not enough available space on filesystem for staging in {inputfile} "
                         f"(size: {size} GB, available: {check_filesystem_availability(self.node_local_prefix)} GB)."
                     )
-                if size is not None and size < 2:
+                if size is not None and size <= 4:
                     self.logger.debug(
                         f"Staging in {inputfile} via sbcast (size: {size} GB)"
                     )

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -15,7 +15,7 @@ import re
 import zlib
 from dataclasses import dataclass, field
 
-from typing import cast
+from typing import cast, Optional
 
 from snakemake.settings.types import StorageSettings
 
@@ -79,8 +79,8 @@ class ExecutorSettings(ExecutorSettingsBase):
             "required": False,
         },
     )
-    node_local_prefix: str = field(
-        default="",
+    node_local_prefix: Optional[str] = field(
+        default=None,
         metadata={
             "help": ("Used to pass a path to a node local directory"),
             "env_var": False,

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -146,7 +146,8 @@ class Executor(RealExecutor):
             self.logger.debug(
                 f"Checking input file {inputfile} with flags {inputfile.flags}"
             )
-            self.logger.debug(f"is_ondemand_eligible: {is_ondemand_eligible(inputfile)}")
+            self.logger.debug("is_ondemand_eligible: "
+                              f"{is_ondemand_eligible(inputfile)}")
             if is_ondemand_eligible(inputfile):
                 # if the file size is < 2GB, we use sbcast, otherwise scp
                 size = get_file_size(inputfile)

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -159,7 +159,8 @@ class Executor(RealExecutor):
                         f"Staging in {inputfile} via scp (size: {size} GB)"
                     )
                     staged_path = stage_in_scp(inputfile, self.node_local_prefix)
-                # next we need to correct the job's input path to point to the staged file
+                # next we need to correct the job's input path to point to the
+                # staged file
                 job.input[n] = staged_path
 
         jobsteps = dict()

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -153,9 +153,11 @@ class Executor(RealExecutor):
                 if size is not None and size > check_filesystem_availability(
                     self.node_local_prefix
                 ):
+                    available = check_filesystem_availability(self.node_local_prefix)
                     raise WorkflowError(
-                        f"Not enough available space on filesystem for staging in {inputfile} "
-                        f"(size: {size} GB, available: {check_filesystem_availability(self.node_local_prefix)} GB)."
+                        "Not enough available space on filesystem for "
+                        f"staging in {inputfile} (size: {size} GB, "
+                        f"available: {available} GB)."
                     )
                 if size is not None and size <= 4:
                     self.logger.debug(

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -14,6 +14,18 @@ import ast
 import re
 import zlib
 from dataclasses import dataclass, field
+
+from pathlib import Path
+from typing import cast
+
+from snakemake.io.flags.access_patterns import (
+    AccessPattern,
+    AccessPatternFactory,
+    STORE_KEY,
+)
+
+from snakemake.settings.types import StorageSettings
+
 from snakemake_interface_executor_plugins.executors.base import SubmittedJobInfo
 from snakemake_interface_executor_plugins.executors.real import RealExecutor
 from snakemake_interface_executor_plugins.jobs import (
@@ -46,6 +58,91 @@ common_settings = CommonSettings(
     auto_deploy_default_storage_provider=False,
     spawned_jobs_assume_shared_fs=True,
 )
+
+
+def should_stage_in(inputfile):
+    """
+    Determine whether an input file should be staged in based on its access pattern.
+    """
+    pattern = inputfile.flags.get(STORE_KEY)
+    return pattern in {AccessPattern.RANDOM, AccessPattern.MULTI}
+
+
+def get_file_size(inputfile):
+    """
+    Get the size of the input file if available, otherwise return None.
+    """
+    size = os.path.getsize(inputfile)
+    # return file size in GB - we do not care for the exact value
+    return size // (1024**3)
+
+
+def get_nodelist():
+    """
+    Get the list of nodes allocated for the job from SLURM environment variables
+    """
+    try:
+        expanded = subprocess.run(
+            ["scontrol", "show", "hostname", "$SLURM_NODELIST"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise WorkflowError(
+            "Failed to expand SLURM nodelist via `scontrol show hostname`."
+        ) from err
+
+    return [host for host in expanded.stdout.splitlines() if host]
+
+
+def get_remote_storage_path():
+    """
+    Get the remote storage path from the environment variable set by Snakemake.
+    """
+    #TODO: This is bullshit - the remote storage path should be passed via
+    # the Snakemake API, just how?
+    pass
+
+
+def stage_in_sbcast(inpath) -> Path:
+    """
+    `sbcast` is a SLURM-build-in utitlity for staging files to the compute nodes.
+    It works on single files and best of files smaller 2GB.
+    It's signature is `sbcast <local_path> <remote_path>`,
+    where the remote path is expected to be on a shared filesystem,
+    but can be outside of the job's working directory.
+    The utility takes care of staging the file to the compute nodes and
+    placing it at the specified remote path.
+
+    Note: it expexts a full absolute input path and a full absolute remote path
+    """
+    remote_path = os.path.join(get_remote_storage_path(), os.path.basename(inpath))
+    try:
+        subprocess.run(
+            ["sbcast", inpath, remote_path],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise WorkflowError(
+            f"Failed to stage in file {inpath} via sbcast to {remote_path}."
+        ) from err
+
+    return Path(remote_path)
+
+
+def stage_in_scp(inpath) -> Path:
+    """
+    `scp` is a standard utility for copying files over SSH. It can be used for staging files.
+    For `scp` to work, host based login via SSH must be set up between the submit host and the
+    compute nodes, and the remote path must be on a shared filesystem.
+    """
+    pass
+
+
+#  [(str(f), f.size()) for f in job.input]
 
 
 @dataclass
@@ -93,6 +190,16 @@ class Executor(RealExecutor):
         # print environment variables for debugging purposes
         self.logger.debug(f"environment: {os.environ}")
 
+    @property
+    def remote_storage_prefix(self) -> str | None:
+        """
+        Here, we consider the remote storage prefix to be a property of the
+        executor, because it is inherent to the execution environment on a
+        cluster.
+        """
+        storage_settings = cast(StorageSettings, self.workflow.storage_settings)
+        return storage_settings.remote_job_local_storage_prefix
+
     def run_job(self, job: JobExecutorInterface):
         # Implement here how to run a job.
         # You can access the job's resources, etc.
@@ -101,6 +208,27 @@ class Executor(RealExecutor):
         # self.report_job_submission(job_info).
         # with job_info being of type
         # snakemake_interface_executor_plugins.executors.base.SubmittedJobInfo.
+
+        for n, inputfile in enumerate(job.input):
+            self.logger.debug(
+                f"Checking input file {inputfile} with flags {inputfile.flags}"
+            )
+            self.logger.debug(f"should_stage_in: {should_stage_in(inputfile)}")
+            if should_stage_in(inputfile):
+                # if the file size is < 2GB, we use sbcast, otherwise scp
+                size = get_file_size(inputfile)
+                if size is not None and size < 2:
+                    self.logger.debug(
+                        f"Staging in {inputfile} via sbcast (size: {size} GB)"
+                    )
+                    staged_path = stage_in_sbcast(inputfile)
+                else:
+                    self.logger.debug(
+                        f"Staging in {inputfile} via scp (size: {size} GB)"
+                    )
+                    staged_path = stage_in_scp(inputfile)
+                # next we need to correct the job's input path to point to the staged file
+                job.input[n] = staged_path
 
         jobsteps = dict()
         call = None

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -91,6 +91,8 @@ class Executor(RealExecutor):
         # check if SLURM_ARRAY_TASK_ID is set, to determine whether this
         # is a job array task
         self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None
+        # print environment variables for debugging purposes
+        self.logger.debug(f"environment: {os.environ}")
 
     def run_job(self, job: JobExecutorInterface):
         # Implement here how to run a job.
@@ -181,6 +183,8 @@ class Executor(RealExecutor):
 
             call = "srun -n1 --cpu-bind=q "
             call += f" {get_cpu_setting(job, self.gpu_job)} "
+            call += f" {get_gpu_setting(job)} "
+            call += f" {get_node_setting(job)} "
             if self.workflow.executor_settings.pass_command_as_script:
                 # format the job to execute with all the snakemake parameters
                 # into a script
@@ -197,8 +201,37 @@ class Executor(RealExecutor):
             self.logger.debug(f"The script for this job is: \n{srun_script}")
         # this dict is to support the to be implemented feature of oversubscription in
         # "ordinary" group jobs.
+        # Sanitize inherited SLURM task/GPU settings for nested srun:
+        # these are allocation-level values and can conflict with explicit step flags.
+        popen_env = os.environ.copy()
+        # Nested srun should not inherit parent step resource defaults.
+        # Keep only allocation identity-related SLURM vars.
+        keep_slurm = {
+            "SLURM_JOB_ID",
+            "SLURM_JOBID",
+            "SLURM_ARRAY_JOB_ID",
+            "SLURM_ARRAY_TASK_ID",
+            "SLURM_ARRAY_TASK_MIN",
+            "SLURM_ARRAY_TASK_MAX",
+            "SLURM_ARRAY_TASK_STEP",
+            "SLURM_CLUSTER_NAME",
+            "SLURM_SUBMIT_DIR",
+            "SLURM_SUBMIT_HOST",
+        }
+        for var in list(popen_env):
+            if var.startswith("SLURM_") and var not in keep_slurm:
+                popen_env.pop(var, None)
+            # Also drop inherited client-side defaults for nested srun/sbatch.
+            # These can silently add options like GRES/TRES to the inner srun.
+            if var.startswith("SRUN_") or var.startswith("SBATCH_"):
+                popen_env.pop(var, None)
+
         jobsteps[job] = subprocess.Popen(
-            call, shell=True, text=True, stdin=subprocess.PIPE
+            call,
+            shell=True,
+            text=True,
+            stdin=subprocess.PIPE,
+            env=popen_env,
         )
         if srun_script is not None:
             try:
@@ -276,6 +309,43 @@ def get_cpu_setting(job: JobExecutorInterface, gpu: bool) -> str:
         return f"--cpus-per-gpu={cpus_per_gpu}"
     else:
         return f"--cpus-per-task={cpus_per_task}"
+
+
+def _coerce_int_resource(value, resource_name: str) -> int:
+    if not isinstance(value, int):
+        raise WorkflowError(f"{resource_name} must be an integer, but is {value}")
+    return value
+
+
+def get_gpu_setting(job: JobExecutorInterface) -> str:
+    # Set GPU count explicitly only when requested by workflow resources.
+    # Keep this key list short and explicit to avoid accidental mappings.
+    gpu_value = None
+    for key in ("gpus", "gpu", "nvidia_gpu"):
+        value = job.resources.get(key)
+        if value is not None:
+            gpu_value = _coerce_int_resource(value, key)
+            break
+
+    if gpu_value is None or gpu_value <= 0:
+        return ""
+    return f"--gpus={gpu_value}"
+
+
+def get_node_setting(job: JobExecutorInterface) -> str:
+    # Force single-node step placement unless user provided explicit node count.
+    node_value = None
+    for key in ("nodes", "node", "slurm_nodes"):
+        value = job.resources.get(key)
+        if value is not None:
+            node_value = _coerce_int_resource(value, key)
+            break
+
+    if node_value is None:
+        return "--nodes=1"
+    if node_value <= 0:
+        raise WorkflowError(f"nodes must be > 0, but is {node_value}")
+    return f"--nodes={node_value}"
 
 
 def parse_array_execs(raw_array_execs) -> dict:

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -33,7 +33,7 @@ from snakemake_interface_common.exceptions import WorkflowError
 
 from .stagein import (
     expand_node_local_prefix,
-    should_stage_in,
+    is_ondemand_eligible,
     get_file_size,
     check_filesystem_availability,
     stage_in_sbcast,
@@ -146,8 +146,8 @@ class Executor(RealExecutor):
             self.logger.debug(
                 f"Checking input file {inputfile} with flags {inputfile.flags}"
             )
-            self.logger.debug(f"should_stage_in: {should_stage_in(inputfile)}")
-            if should_stage_in(inputfile):
+            self.logger.debug(f"is_ondemand_eligible: {is_ondemand_eligible(inputfile)}")
+            if is_ondemand_eligible(inputfile):
                 # if the file size is < 2GB, we use sbcast, otherwise scp
                 size = get_file_size(inputfile)
                 if size is not None and size > check_filesystem_availability(

--- a/snakemake_executor_plugin_slurm_jobstep/__init__.py
+++ b/snakemake_executor_plugin_slurm_jobstep/__init__.py
@@ -15,14 +15,7 @@ import re
 import zlib
 from dataclasses import dataclass, field
 
-from pathlib import Path
 from typing import cast
-
-from snakemake.io.flags.access_patterns import (
-    AccessPattern,
-    AccessPatternFactory,
-    STORE_KEY,
-)
 
 from snakemake.settings.types import StorageSettings
 
@@ -37,6 +30,14 @@ from snakemake_interface_executor_plugins.settings import (
     ExecutorSettingsBase,
 )
 from snakemake_interface_common.exceptions import WorkflowError
+
+from .stagein import (
+    expand_node_local_prefix,
+    should_stage_in,
+    get_file_size,
+    stage_in_sbcast,
+    stage_in_scp,
+)
 
 # Required:
 # Specify common settings shared by various executors.
@@ -60,91 +61,6 @@ common_settings = CommonSettings(
 )
 
 
-def should_stage_in(inputfile):
-    """
-    Determine whether an input file should be staged in based on its access pattern.
-    """
-    pattern = inputfile.flags.get(STORE_KEY)
-    return pattern in {AccessPattern.RANDOM, AccessPattern.MULTI}
-
-
-def get_file_size(inputfile):
-    """
-    Get the size of the input file if available, otherwise return None.
-    """
-    size = os.path.getsize(inputfile)
-    # return file size in GB - we do not care for the exact value
-    return size // (1024**3)
-
-
-def get_nodelist():
-    """
-    Get the list of nodes allocated for the job from SLURM environment variables
-    """
-    try:
-        expanded = subprocess.run(
-            ["scontrol", "show", "hostname", "$SLURM_NODELIST"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as err:
-        raise WorkflowError(
-            "Failed to expand SLURM nodelist via `scontrol show hostname`."
-        ) from err
-
-    return [host for host in expanded.stdout.splitlines() if host]
-
-
-def get_remote_storage_path():
-    """
-    Get the remote storage path from the environment variable set by Snakemake.
-    """
-    #TODO: This is bullshit - the remote storage path should be passed via
-    # the Snakemake API, just how?
-    pass
-
-
-def stage_in_sbcast(inpath) -> Path:
-    """
-    `sbcast` is a SLURM-build-in utitlity for staging files to the compute nodes.
-    It works on single files and best of files smaller 2GB.
-    It's signature is `sbcast <local_path> <remote_path>`,
-    where the remote path is expected to be on a shared filesystem,
-    but can be outside of the job's working directory.
-    The utility takes care of staging the file to the compute nodes and
-    placing it at the specified remote path.
-
-    Note: it expexts a full absolute input path and a full absolute remote path
-    """
-    remote_path = os.path.join(get_remote_storage_path(), os.path.basename(inpath))
-    try:
-        subprocess.run(
-            ["sbcast", inpath, remote_path],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as err:
-        raise WorkflowError(
-            f"Failed to stage in file {inpath} via sbcast to {remote_path}."
-        ) from err
-
-    return Path(remote_path)
-
-
-def stage_in_scp(inpath) -> Path:
-    """
-    `scp` is a standard utility for copying files over SSH. It can be used for staging files.
-    For `scp` to work, host based login via SSH must be set up between the submit host and the
-    compute nodes, and the remote path must be on a shared filesystem.
-    """
-    pass
-
-
-#  [(str(f), f.size()) for f in job.input]
-
-
 @dataclass
 class ExecutorSettings(ExecutorSettingsBase):
     """Settings for the SLURM jobstep executor plugin."""
@@ -158,6 +74,14 @@ class ExecutorSettings(ExecutorSettingsBase):
                 "call. Useful when a limit exists on SLURM command line length (ie. "
                 "max_submit_line_size). (internal use only)"
             ),
+            "env_var": False,
+            "required": False,
+        },
+    )
+    node_local_prefix: str = field(
+        default="",
+        metadata={
+            "help": ("Used to pass a path to a node local directory"),
             "env_var": False,
             "required": False,
         },
@@ -188,7 +112,15 @@ class Executor(RealExecutor):
         # is a job array task
         self.job_array_task = os.getenv("SLURM_ARRAY_TASK_ID") is not None
         # print environment variables for debugging purposes
-        self.logger.debug(f"environment: {os.environ}")
+        # self.logger.debug(f"environment: {os.environ}")
+        self.logger.debug(f"Storage setting remote: {StorageSettings.__dict__}")
+        # check whether the remote path is present
+        if self.workflow.executor_settings.node_local_prefix:
+            expanded_prefix = expand_node_local_prefix(
+                self.workflow.executor_settings.node_local_prefix
+            )
+            self.logger.debug(f"Using node local prefix: {expanded_prefix}")
+            self.node_local_prefix = expanded_prefix
 
     @property
     def remote_storage_prefix(self) -> str | None:
@@ -221,12 +153,12 @@ class Executor(RealExecutor):
                     self.logger.debug(
                         f"Staging in {inputfile} via sbcast (size: {size} GB)"
                     )
-                    staged_path = stage_in_sbcast(inputfile)
+                    staged_path = stage_in_sbcast(inputfile, self.node_local_prefix)
                 else:
                     self.logger.debug(
                         f"Staging in {inputfile} via scp (size: {size} GB)"
                     )
-                    staged_path = stage_in_scp(inputfile)
+                    staged_path = stage_in_scp(inputfile, self.node_local_prefix)
                 # next we need to correct the job's input path to point to the staged file
                 job.input[n] = staged_path
 

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -139,7 +139,7 @@ def stage_in_scp(inpath, remote_directory):
     # as scp does not have a built-in way to copy to multiple hosts
     for node in nodelist:
         if node == get_nodename():
-            # if the node is the same as the current node, we can just 
+            # if the node is the same as the current node, we can just
             # copy the file locally
             try:
                 subprocess.run(

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -118,7 +118,8 @@ def get_nodename():
     nodename = os.environ.get("SLURMD_NODENAME")
     if nodename is None:
         raise WorkflowError(
-            "Failed to get current node name from SLURM environment variable SLURMD_NODENAME."
+            "Failed to get current node name from SLURM environment "
+            "variable SLURMD_NODENAME."
         )
     return nodename
 
@@ -138,7 +139,8 @@ def stage_in_scp(inpath, remote_directory):
     # as scp does not have a built-in way to copy to multiple hosts
     for node in nodelist:
         if node == get_nodename():
-            # if the node is the same as the current node, we can just copy the file locally
+            # if the node is the same as the current node, we can just 
+            # copy the file locally
             try:
                 subprocess.run(
                     ["cp", inpath, str(remote_path)],

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -103,17 +103,23 @@ def stage_in_scp(inpath, remote_directory):
     """
     fname = Path(inpath).name
     remote_path = Path(remote_directory) / fname
-    try:
-        subprocess.run(
-            ["scp", inpath, f"{remote_path}"],
-            check=True,
+
+    nodelist = get_nodelist()
+    # we need to iterate over the nodelist and scp to each node, 
+    # as scp does not have a built-in way to copy to multiple hosts
+    for node in nodelist:
+        try:
+            subprocess.run(
+                ["scp", inpath, f"{node}:{remote_path}"],
+                check=True,
             capture_output=True,
-            text=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as err:
-        raise WorkflowError(
-            f"Failed to stage in file {inpath} via scp to {remote_path}."
-        ) from err
+                text=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            raise WorkflowError(
+                f"Failed to stage in file {inpath} via scp to {remote_path}."
+            ) from err
+
     try:
         staged_path = inpath.__class__(
             str(remote_path), rule=getattr(inpath, "rule", None)
@@ -124,5 +130,3 @@ def stage_in_scp(inpath, remote_directory):
     except Exception:
         return str(remote_path)
 
-
-#  [(str(f), f.size()) for f in job.input]

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -1,0 +1,128 @@
+import os
+import re
+from pathlib import Path
+import subprocess
+
+from snakemake.io.flags.access_patterns import (
+    AccessPattern,
+    STORE_KEY,
+)
+from snakemake_interface_common.exceptions import WorkflowError
+
+_ENV_MARKER = re.compile(r"__ENV(?:__|_)([A-Z0-9]+(?:_[A-Z0-9]+)*)__")
+
+
+def expand_node_local_prefix(value: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        return os.environ.get(match.group(1), "")
+
+    return _ENV_MARKER.sub(repl, value)
+
+
+def should_stage_in(inputfile):
+    """
+    Determine whether an input file should be staged in based on its access pattern.
+    """
+    pattern = inputfile.flags.get(STORE_KEY)
+    return pattern in {AccessPattern.RANDOM, AccessPattern.MULTI}
+
+
+def get_file_size(inputfile):
+    """
+    Get the size of the input file if available, otherwise return None.
+    """
+    size = os.path.getsize(inputfile)
+    # return file size in GB - we do not care for the exact value
+    return size // (1024**3)
+
+
+def get_nodelist():
+    """
+    Get the list of nodes allocated for the job from SLURM environment variables
+    """
+    try:
+        expanded = subprocess.run(
+            ["scontrol", "show", "hostname", "$SLURM_NODELIST"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise WorkflowError(
+            "Failed to expand SLURM nodelist via `scontrol show hostname`."
+        ) from err
+
+    return [host for host in expanded.stdout.splitlines() if host]
+
+
+def stage_in_sbcast(inpath, remote_directory):
+    """
+    `sbcast` is a SLURM-build-in utitlity for staging files to the compute nodes.
+    It works on single files and best of files smaller 2GB.
+    It's signature is `sbcast <local_path> <remote_path>`,
+    where the remote path is expected to be on a shared filesystem,
+    but can be outside of the job's working directory.
+    The utility takes care of staging the file to the compute nodes and
+    placing it at the specified remote path.
+
+    Note: it expexts a full absolute input path and a full absolute remote path
+    """
+    # The remote path is combined from the input file name and the
+    # remote directory.
+
+    fname = Path(inpath).name
+    remote_path = Path(remote_directory) / fname
+    try:
+        subprocess.run(
+            ["sbcast", inpath, str(remote_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise WorkflowError(
+            f"Failed to stage in file {inpath} via sbcast to {remote_path}."
+        ) from err
+
+    try:
+        staged_path = inpath.__class__(
+            str(remote_path), rule=getattr(inpath, "rule", None)
+        )
+        if hasattr(staged_path, "clone_flags"):
+            staged_path.clone_flags(inpath)
+        return staged_path
+    except Exception:
+        return str(remote_path)
+
+
+def stage_in_scp(inpath, remote_directory):
+    """
+    `scp` is a standard utility for copying files over SSH. It can be used for staging files.
+    For `scp` to work, host based login via SSH must be set up between the submit host and the
+    compute nodes, and the remote path must be on a shared filesystem.
+    """
+    fname = Path(inpath).name
+    remote_path = Path(remote_directory) / fname
+    try:
+        subprocess.run(
+            ["scp", inpath, f"{remote_path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise WorkflowError(
+            f"Failed to stage in file {inpath} via scp to {remote_path}."
+        ) from err
+    try:
+        staged_path = inpath.__class__(
+            str(remote_path), rule=getattr(inpath, "rule", None)
+        )
+        if hasattr(staged_path, "clone_flags"):
+            staged_path.clone_flags(inpath)
+        return staged_path
+    except Exception:
+        return str(remote_path)
+
+
+#  [(str(f), f.size()) for f in job.input]

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -105,14 +105,14 @@ def stage_in_scp(inpath, remote_directory):
     remote_path = Path(remote_directory) / fname
 
     nodelist = get_nodelist()
-    # we need to iterate over the nodelist and scp to each node, 
+    # we need to iterate over the nodelist and scp to each node,
     # as scp does not have a built-in way to copy to multiple hosts
     for node in nodelist:
         try:
             subprocess.run(
                 ["scp", inpath, f"{node}:{remote_path}"],
                 check=True,
-            capture_output=True,
+                capture_output=True,
                 text=True,
             )
         except (subprocess.CalledProcessError, FileNotFoundError) as err:
@@ -129,4 +129,3 @@ def stage_in_scp(inpath, remote_directory):
         return staged_path
     except Exception:
         return str(remote_path)
-

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -97,8 +97,9 @@ def stage_in_sbcast(inpath, remote_directory):
 
 def stage_in_scp(inpath, remote_directory):
     """
-    `scp` is a standard utility for copying files over SSH. It can be used for staging files.
-    For `scp` to work, host based login via SSH must be set up between the submit host and the
+    `scp` is a standard utility for copying files over SSH. It can be used for
+    staging-in files. For `scp` to work, host based login via SSH or passphrase
+    based login must be set up between the submit host and the
     compute nodes, and the remote path must be on a shared filesystem.
     """
     fname = Path(inpath).name

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -19,7 +19,7 @@ def expand_node_local_prefix(value: str) -> str:
     return _ENV_MARKER.sub(repl, value)
 
 
-def should_stage_in(inputfile):
+def is_ondemand_eligible(inputfile):
     """
     Determine whether an input file should be staged in based on its access pattern.
     """

--- a/snakemake_executor_plugin_slurm_jobstep/stagein.py
+++ b/snakemake_executor_plugin_slurm_jobstep/stagein.py
@@ -40,9 +40,10 @@ def get_nodelist():
     """
     Get the list of nodes allocated for the job from SLURM environment variables
     """
+    evaluate_nodelist = os.environ.get("SLURM_NODELIST")
     try:
         expanded = subprocess.run(
-            ["scontrol", "show", "hostname", "$SLURM_NODELIST"],
+            ["scontrol", "show", "hostname", evaluate_nodelist],
             check=True,
             capture_output=True,
             text=True,
@@ -53,6 +54,21 @@ def get_nodelist():
         ) from err
 
     return [host for host in expanded.stdout.splitlines() if host]
+
+
+def check_filesystem_availability(remote_directory):
+    """
+    Check the available size on the filesystem where the remote directory is located.
+    """
+    try:
+        statvfs = os.statvfs(remote_directory)
+        # Calculate available space in GB
+        available_gb = (statvfs.f_bavail * statvfs.f_frsize) // (1024**3)
+        return available_gb
+    except OSError as err:
+        raise WorkflowError(
+            f"Failed to check filesystem for remote directory {remote_directory}."
+        ) from err
 
 
 def stage_in_sbcast(inpath, remote_directory):
@@ -95,6 +111,18 @@ def stage_in_sbcast(inpath, remote_directory):
         return str(remote_path)
 
 
+def get_nodename():
+    """
+    Get the name of the current node from SLURM environment variables.
+    """
+    nodename = os.environ.get("SLURMD_NODENAME")
+    if nodename is None:
+        raise WorkflowError(
+            "Failed to get current node name from SLURM environment variable SLURMD_NODENAME."
+        )
+    return nodename
+
+
 def stage_in_scp(inpath, remote_directory):
     """
     `scp` is a standard utility for copying files over SSH. It can be used for
@@ -109,6 +137,20 @@ def stage_in_scp(inpath, remote_directory):
     # we need to iterate over the nodelist and scp to each node,
     # as scp does not have a built-in way to copy to multiple hosts
     for node in nodelist:
+        if node == get_nodename():
+            # if the node is the same as the current node, we can just copy the file locally
+            try:
+                subprocess.run(
+                    ["cp", inpath, str(remote_path)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except (subprocess.CalledProcessError, FileNotFoundError) as err:
+                raise WorkflowError(
+                    f"Failed to stage in file {inpath} via local copy to {remote_path}."
+                ) from err
+            continue
         try:
             subprocess.run(
                 ["scp", inpath, f"{node}:{remote_path}"],

--- a/tests/test_stagein.py
+++ b/tests/test_stagein.py
@@ -1,0 +1,13 @@
+from snakemake_executor_plugin_slurm_jobstep.stagein import expand_node_local_prefix
+
+
+def test_expand_node_local_prefix_replaces_env_markers(monkeypatch):
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    value = "/localscratch/__ENV_SLURM_JOB_ID__/run"
+    assert expand_node_local_prefix(value) == "/localscratch/12345/run"
+
+
+def test_expand_node_local_prefix_leaves_plain_paths_unchanged(monkeypatch):
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    value = "/localscratch/run"
+    assert expand_node_local_prefix(value) == "/localscratch/run"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,6 +18,8 @@ from snakemake_executor_plugin_slurm_jobstep import (
     ExecutorSettings,
     _decompress_array_task_call,
     _is_first_array_task,
+    get_gpu_setting,
+    get_node_setting,
     parse_array_execs,
     strip_array_execs_option,
 )
@@ -151,3 +153,38 @@ def test_decompress_array_task_call_valid_payload():
     compressed = zlib.compress(expected.encode("utf-8")).hex()
     resolved = _decompress_array_task_call('{"2": "' + compressed + '"}', 2)
     assert resolved == expected
+
+
+class _DummyJob:
+    def __init__(self, resources):
+        self.resources = resources
+
+
+def test_get_gpu_setting_empty_when_not_set():
+    assert get_gpu_setting(_DummyJob({})) == ""
+
+
+def test_get_gpu_setting_from_gpus_resource():
+    assert get_gpu_setting(_DummyJob({"gpus": 2})) == "--gpus=2"
+
+
+def test_get_gpu_setting_zero_disables_flag():
+    assert get_gpu_setting(_DummyJob({"gpus": 0})) == ""
+
+
+def test_get_gpu_setting_non_integer_raises():
+    with pytest.raises(WorkflowError, match="gpus must be an integer"):
+        get_gpu_setting(_DummyJob({"gpus": "2"}))
+
+
+def test_get_node_setting_defaults_to_one():
+    assert get_node_setting(_DummyJob({})) == "--nodes=1"
+
+
+def test_get_node_setting_from_nodes_resource():
+    assert get_node_setting(_DummyJob({"nodes": 3})) == "--nodes=3"
+
+
+def test_get_node_setting_non_positive_raises():
+    with pytest.raises(WorkflowError, match="nodes must be > 0"):
+        get_node_setting(_DummyJob({"nodes": 0}))


### PR DESCRIPTION
This PR should enable an automated stage-in of input files on HPC clusters.

A detailed description of features and intentions is at the corresponding PR for the submit plugin: https://github.com/snakemake/snakemake-executor-plugin-slurm/pull/468



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced node-local input staging for SLURM compute nodes to improve data locality
  * Added `node_local_prefix` executor configuration option for specifying node-local storage paths
  * Automatic disk space availability validation before staging inputs

* **Tests**
  * Added unit tests for node-local path configuration validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->